### PR TITLE
Feature/reset game after win

### DIFF
--- a/game.js
+++ b/game.js
@@ -3,12 +3,12 @@ class Game {
     this.players = [];
     this.spacesOccupied = [];
     this.whosTurn = '';
-  }
+  };
 
   startNewGame() {
     this.players.push(nachoPlayer, esqueletoPlayer);
     this.whosTurn = nachoPlayer;
-  }
+  };
 
   switchPlayer() {
     if (this.whosTurn === nachoPlayer) {
@@ -17,7 +17,7 @@ class Game {
       this.whosTurn = nachoPlayer;
     }
     updateAnnouncerWithNewPlayer();
-  }
+  };
 
   updateSpacesOccupied(event) {
     this.spacesOccupied.push({[event.target.id]: [this.whosTurn]});
@@ -33,23 +33,10 @@ class Game {
     }
   };
 
-  continueTurn(event) {
-    this.updateSpacesOccupied(event);
-    updateIcon(event);
-    if (this.checkForWin()) {
-      this.whosTurn.increaseWins();
-      updateAnnouncerWithWin();
-      updateWinText(this.checkForWin());
-      setTimeout(restartGame, 3000);
-      return;
-    }
-    this.switchPlayer();
-  }
-
   updateWins() {
     this.whosTurn.increaseWins();
     console.log(this.whosTurn.wins);
-  }
+  };
 
   checkIfOccupiedSpace(event) {
       if ((!this.spacesOccupied.includes(event.target.id)) && (!event.target.classList.contains('game-piece'))) {
@@ -57,19 +44,19 @@ class Game {
       }  else {
         alert('Choose an empty spot, silly goose!')
       }
-    }
-
-    restartGame() {
-      this.resetSpacesOccupied();
-      this.resetPlayerSpacesOccupied();
-      this.changeWhosFirst();
-      updateAnnouncerWithNewPlayer();
-      clearGameBoard();
-    }
+    };
 
     resetSpacesOccupied() {
       this.spacesOccupied = [];
     };
+
+    // restartGame() {
+    //   this.resetSpacesOccupied();
+    //   this.resetPlayerSpacesOccupied();
+    //   this.changeWhosFirst();
+    //   updateAnnouncerWithNewPlayer();
+    //   clearGameBoard();
+    // };
 
     resetPlayerSpacesOccupied() {
       nachoPlayer.spacesOccupiedByPlayer = [];
@@ -86,5 +73,19 @@ class Game {
         esqueletoPlayer.isFirst = false
         this.whosTurn = nachoPlayer;
       }
-    }
-  }
+    };
+
+    continueTurn(event) {
+      this.updateSpacesOccupied(event);
+      updateIcon(event);
+      if (this.checkForWin()) {
+        this.whosTurn.increaseWins();
+        updateAnnouncerWithWin();
+        updateWinText(this.checkForWin());
+        setTimeout(restartGame, 3000);
+        return;
+      }
+      this.switchPlayer();
+    };
+
+  };

--- a/main.js
+++ b/main.js
@@ -64,5 +64,21 @@ function updateWinText(winner) {
 }
 
 function clearGameBoard() {
-  gameBoxes.innerHTML = '';
+  gameBox1.innerHTML = '';
+  gameBox2.innerHTML = '';
+  gameBox3.innerHTML = '';
+  gameBox4.innerHTML = '';
+  gameBox5.innerHTML = '';
+  gameBox6.innerHTML = '';
+  gameBox7.innerHTML = '';
+  gameBox8.innerHTML = '';
+  gameBox9.innerHTML = '';
 }
+
+function restartGame() {
+  game.resetSpacesOccupied();
+  game.resetPlayerSpacesOccupied();
+  game.changeWhosFirst();
+  updateAnnouncerWithNewPlayer();
+  clearGameBoard();
+};


### PR DESCRIPTION
This branch added functionality that resets the gameboard and data model arrays upon player win. A bug still persists that won't allow a player to win if they've got other positions on top of the winning game board positions.